### PR TITLE
Add SINGLE_FILE

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Yamaha OPL2/3 FM synth chip emulator",
   "main": "index.js",
   "scripts": {
-    "build": "emcc --bind -std=c++11 -O3 -I src -o lib/opl.js -Wno-switch -s EXPORT_NAME=\"opl\" -s INVOKE_RUN=0 -s MODULARIZE=1 -s FILESYSTEM=0 -s NODEJS_CATCH_EXIT=0 -s ALLOW_MEMORY_GROWTH=0 -s TOTAL_STACK=8192 -s TOTAL_MEMORY=65536 src/dbopl.cpp src/index.cpp",
+    "build": "emcc --bind -std=c++11 -O3 -I src -o lib/opl.js -s SINGLE_FILE -Wno-switch -s EXPORT_NAME=\"opl\" -s INVOKE_RUN=0 -s MODULARIZE=1 -s FILESYSTEM=0 -s NODEJS_CATCH_EXIT=0 -s ALLOW_MEMORY_GROWTH=0 -s TOTAL_STACK=8192 -s TOTAL_MEMORY=65536 src/dbopl.cpp src/index.cpp",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
This adds `SINGLE_FILE` option, which will make it work easier in various places. It basically just inlines the wasm-bytes, so the CDN/host doesn't need to provide the wasm-file in a hardcoded location, and the js doesn't need to try to figure out where it's stored.

Once this is published, for example, this should work:

```html
<script type="importmap">
  {
    "imports": {
      "@malvineous/opl": "https://esm.sh/@malvineous/opl"
    }
  }
</script>
<script type="module">
import OPL from '@malvineous/opl'
</script>
```

Currently, this results in trying to download it from my host, at the root:

<img width="804" alt="Screenshot 2024-11-21 at 6 19 43 PM" src="https://github.com/user-attachments/assets/547c5dcc-0189-42a9-b4be-af3f85f57897">

Additionally, I am a big fan of directly outputting files from emscripten, using `.mjs` (`-o lib/opl3-wasm.mjs`) to trigger ESM, since modern browsers/node can load those directly, but I didn't include that change (so it works like it does now.)
